### PR TITLE
Drop avahi-daemon-equiv-deb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ install:
 	# copy static files verbatim
 	/bin/cp -a static/* $(DESTDIR)
 	/bin/cp $(SNAPCRAFT_PART_INSTALL)/../../consoleconf-deb/install/*.deb $(DESTDIR)/tmp
-	/bin/cp $(SNAPCRAFT_PART_INSTALL)/../../avahi-daemon-equiv-deb/install/*.deb $(DESTDIR)/tmp
 	# customize
 	set -ex; for f in ./hooks/[0-9]*.chroot; do \
 		/bin/cp -a $$f $(DESTDIR)/tmp && \

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -85,7 +85,7 @@ case "$(dpkg --print-architecture)" in
         ;;
 esac
 
-# Install self-built console-conf and fake avahi-daemon
+# Install self-built console-conf
 find /tmp -name '*.deb' -print0 | xargs -0 apt install -y
 rm /tmp/*.deb
 

--- a/hooks/013-add-mdns-hostname-resolution.chroot
+++ b/hooks/013-add-mdns-hostname-resolution.chroot
@@ -3,15 +3,15 @@
 export DEBIAN_FRONTEND=noninteractive
 
 echo "Installing libnss-mdns"
-apt-get install -y libnss-mdns
+apt-get install -y --no-install-recommends libnss-mdns
 
 # Install additional multi-arch versions of modules
 case "$(dpkg --print-architecture)" in
     amd64)
-        apt-get install -y libnss-mdns:i386
+        apt-get install -y --no-install-recommends libnss-mdns:i386
         ;;
     arm64)
-        apt-get install -y libnss-mdns:armhf
+        apt-get install -y --no-install-recommends libnss-mdns:armhf
         ;;
     *)
         ;;

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -45,32 +45,9 @@ parts:
       # https://github.com/snapcore/snapcraft/pull/2251
       export PATH="$PATH:/snap/snapcraft/current/bin/scriptlet-bin"
       snapcraftctl prime
-  avahi-daemon-equiv-deb:
-    plugin: nil
-    build-packages:
-      - equivs
-    override-build: |
-      cat > avahi-daemon.control << \EOF
-      Section: misc
-      Priority: optional
-      Standards-Version: 3.9.2
-      Architecture: all
-
-      Package: avahi-daemon
-      Version: 1000
-      Multi-Arch: foreign
-      Description: A dummy version of avahi-daemon
-
-      EOF
-      unset LD_FLAGS LD_LIBRARY_PATH
-      equivs-build avahi-daemon.control
-      cp avahi-daemon_*.deb $SNAPCRAFT_PART_INSTALL
-    stage:
-      - -avahi-daemon_*.deb
   bootstrap:
     after:
       - consoleconf-deb
-      - avahi-daemon-equiv-deb
     plugin: make
     source: .
     build-packages:


### PR DESCRIPTION
In jammy, nss-mdns has downgraded avahi-daemon from Depends to
Recommends, thus one can simply install libnss-mdns without recommends
to avoid including avahi-daemon.

Link: https://launchpad.net/ubuntu/+source/nss-mdns/0.15.1-1ubuntu1