### PR TITLE
Handle PPAs being served from ppa.launchpadcontent.net

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -22,7 +22,7 @@ mkdir -p /var/log/journal
 # shellcheck disable=SC1091
 CODENAME=$(. /etc/os-release; echo "$UBUNTU_CODENAME")
 # enable the foundations ubuntu-image PPA
-echo "deb http://ppa.launchpad.net/canonical-foundations/ubuntu-image/ubuntu $CODENAME main" > /etc/apt/sources.list.d/ubuntu-image.list
+echo "deb http://ppa.launchpadcontent.net/canonical-foundations/ubuntu-image/ubuntu $CODENAME main" > /etc/apt/sources.list.d/ubuntu-image.list
 
 cat >/etc/apt/trusted.gpg.d/canonical-foundations-ubuntu-image.asc <<EOF
 -----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/hooks/600-no-debian.chroot
+++ b/hooks/600-no-debian.chroot
@@ -15,7 +15,7 @@ dpkg -l > usr/share/snappy/dpkg.list
   # fill in ppa information in yaml file
   printf 'package-repositories:\n'
   find /etc/apt/ -name \*.list | while IFS= read -r APT; do
-    grep -o "^deb http://ppa.launchpad.net/[a-z0-9\.\+\-]\+/[a-z0-9\.\+\-]\+/[a-z0-9\.\+\-]\+" "$APT" | while read -r ENTRY ; do
+    grep -Eo "^deb https?://ppa\.launchpad(content)?\.net/[a-z0-9\.\+\-]+/[a-z0-9\.\+\-]+/[a-z0-9\.\+\-]+" "$APT" | while read -r ENTRY ; do
       USER=$(echo "$ENTRY" | cut -d/ -f4)
       PPA=$(echo "$ENTRY" | cut -d/ -f5)
       DISTRO=$(echo "$ENTRY" | cut -d/ -f6)


### PR DESCRIPTION
We now have a new HTTPS-capable domain for public PPAs, namely
ppa.launchpadcontent.net.  Adjust various bits of the build system to
accept that.