### PR TITLE
many: change [Cc]ore\ *20 -> [Cc]or\ *22

### DIFF
--- a/hook-tests/014-set-motd.test
+++ b/hook-tests/014-set-motd.test
@@ -2,7 +2,7 @@
 
 set -e
 
-grep -q "This Ubuntu Core 20 machine is a tiny" etc/motd
+grep -q "This Ubuntu Core 22 machine is a tiny" etc/motd
 
 test ! -e etc/default/motd-news
 test ! -e etc/update-motd.d/10-help-text

--- a/hooks/014-set-motd.chroot
+++ b/hooks/014-set-motd.chroot
@@ -5,7 +5,7 @@ cat >/etc/motd<<EOF
  * Community:       https://forum.snapcraft.io
  * Snaps:           https://snapcraft.io
 
-This Ubuntu Core 20 machine is a tiny, transactional edition of Ubuntu,
+This Ubuntu Core 22 machine is a tiny, transactional edition of Ubuntu,
 designed for appliances, firmware and fixed-function VMs.
 
 If all the software you care about is available as snaps, you are in

--- a/hooks/018-set-os-release.chroot
+++ b/hooks/018-set-os-release.chroot
@@ -2,10 +2,10 @@
 
 cat >/usr/lib/os-release<<EOF
 NAME="Ubuntu Core"
-VERSION="20"
+VERSION="22"
 ID=ubuntu-core
-PRETTY_NAME="Ubuntu Core 20"
-VERSION_ID="20"
+PRETTY_NAME="Ubuntu Core 22"
+VERSION_ID="22"
 HOME_URL="https://snapcraft.io/"
 BUG_REPORT_URL="https://bugs.launchpad.net/snappy/"
 EOF

--- a/hooks/024-configure-bootchart.chroot
+++ b/hooks/024-configure-bootchart.chroot
@@ -1,7 +1,7 @@
 #! /bin/sh -ex
 
 if [ "$(dpkg --print-architecture)" = "riscv64" ]; then
-    echo "core20 riscv64 does not support this functionality"
+    echo "core22 riscv64 does not support this functionality"
     exit 0
 fi
 

--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -70,10 +70,10 @@ rmdir /var/log/private
 # clean leftovers from the build
 rm /var/log/*
 
-# no "local" on core20
+# no "local" on core22
 # shellcheck disable=SC2114
 rm -rf -- /var/local /usr/local
-# we need this for the core20 base snap when using with classic snaps
+# we need this for the core22 base snap when using with classic snaps
 # for the "interfaces-desktop-host-fonts"
 mkdir -p /usr/local/share/fonts
 

--- a/hooks/901-cleanup-timesyncd.chroot
+++ b/hooks/901-cleanup-timesyncd.chroot
@@ -3,7 +3,7 @@
 set -e
 
 # With newer systemd, systemd-timesyncd switched from a regular user usage to
-# dynamic users.  In cases of upgrades from an older core20 system or in some
+# dynamic users.  In cases of upgrades from an older core22 system or in some
 # other weird situations the old timesync directory needs removal as otherwise
 # systemd will fail creating dynamic user symlink and fail to start timesyncd.
 # XXX: This might not be needed in the end, but certainly useful now

--- a/static/etc/issue
+++ b/static/etc/issue
@@ -1,2 +1,2 @@
-Ubuntu Core 20 on \4 (\l)
+Ubuntu Core 22 on \4 (\l)
 

--- a/static/etc/issue.net
+++ b/static/etc/issue.net
@@ -1,2 +1,2 @@
-Ubuntu Core 20
+Ubuntu Core 22
 

--- a/static/usr/lib/core/handle-writable-paths
+++ b/static/usr/lib/core/handle-writable-paths
@@ -2,7 +2,7 @@
 #
 # Extracted code from:
 # https://github.com/snapcore/core-build/blob/master/initramfs/scripts/ubuntu-core-rootfs
-# to keep in the core20+ snap in sync with the writable-path file.
+# to keep in the core22+ snap in sync with the writable-path file.
 #
 # Having it here means we don't need to rebuld all kernels if this file
 # changes.


### PR DESCRIPTION
While creating some test-snapd-*-core22 snaps I noticed that
the core22 has some outdated /etc/os-release date. This
commit fixes this.