### PR TITLE
hooks: create mount point for piboot bootloader

### DIFF
--- a/hook-tests/016-ensure-bootloaders.test
+++ b/hook-tests/016-ensure-bootloaders.test
@@ -3,5 +3,5 @@
 test -d boot/androidboot
 test -d boot/uboot
 test -d boot/grub
-
+test -d boot/piboot
 

--- a/hooks/016-ensure-bootloaders.chroot
+++ b/hooks/016-ensure-bootloaders.chroot
@@ -5,6 +5,7 @@ mkdir -p /boot/androidboot
 mkdir -p /boot/uboot
 mkdir -p /boot/grub
 mkdir -p /boot/efi
+mkdir -p /boot/piboot
 
 echo "Add uboot config on arm"
 case "$(dpkg --print-architecture)" in


### PR DESCRIPTION
This will be needed when https://github.com/snapcore/snapd/pull/11068 is merged.