### PR TITLE
hooks: mkdir /var/cups to avoid writable mimic creation for snaps using cups

### DIFF
--- a/hooks/020-extra-files.chroot
+++ b/hooks/020-extra-files.chroot
@@ -24,6 +24,9 @@ mkdir -p /var/cache/snapd
 # workaround for seeding bug
 mkdir -p /var/lib/snapd/apparmor/profiles
 
+# workaround for cups interface to prevent creating writable mimics
+mkdir -p /var/cups
+
 echo "creating extra systemd dirs"
 mkdir -p /var/lib/systemd/coredump
 mkdir -p /var/lib/private/systemd


### PR DESCRIPTION
Snaps using the cups interface with the cups snap as of snapd 2.55 will create
a bind mount of /run/cups -> /var/cups, which since /var/cups does not exist
will trigger the writable mimic code to create a writable mimic on /var. This
results in a fair amount of extra bind mounts for every directory in /var, so
creating this directory empty in the base snap ensures that no writable mimic
need be created.

Note that this will result in review-tools complaining when this is merged and a
new core22 is uploaded since a new directory is being added to the base snap,
but this is okay.