### PR TITLE
Stop running auto-import directly from udevd

### DIFF
--- a/static/usr/lib/systemd/system/snapd.autoimport-device@.service
+++ b/static/usr/lib/systemd/system/snapd.autoimport-device@.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Auto import assertions from a specific block device
+After=snapd.service snapd.socket snapd.seeded.service
+ConditionKernelCommandLine=snapd_recovery_mode=run
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/snap auto-import --mount=/dev/%i
+PrivateMounts=yes

--- a/static/usr/lib/udev/rules.d/66-snapd-autoimport.rules
+++ b/static/usr/lib/udev/rules.d/66-snapd-autoimport.rules
@@ -1,3 +1,2 @@
-# probe for assertions, must run before udisks2
-ACTION=="add", SUBSYSTEM=="block", KERNEL!="loop*", KERNEL!="ram*" \
-    RUN+="/usr/bin/unshare -m /usr/bin/snap auto-import --mount=/dev/%k"
+ACTION=="add|change", SUBSYSTEM=="block", KERNEL!="loop*", KERNEL!="ram*" \
+    ENV{SYSTEMD_WANTS}+="snapd.autoimport-device@%k.service"


### PR DESCRIPTION
`snap auto-import` cannot run anymore because of sandboxing of
systemd-udevd. Instead we need to schedule a systemd service.

~~It could be an issue for users using udisks2, where a logged in user
would automatically mount disks marked as `UDISKS_AUTO`. For a short
time, snap could have mounted the device and udisks might fail to
mount.  For this reason we introduce `SNAP_AUTO_IMPORT` so that users
can introduce a custom udev rule to disable auto import on devices
(all or filtered).~~