### PR TITLE
hooks: use --no-install-recommends in all installations

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -87,7 +87,7 @@ case "$(dpkg --print-architecture)" in
 esac
 
 # Install self-built console-conf
-find /tmp -name '*.deb' -print0 | xargs -0 apt install -y
+find /tmp -name '*.deb' -print0 | xargs -0 apt install --no-install-recommends -y
 rm /tmp/*.deb
 
 apt autoremove -y

--- a/hooks/012-add-foreign-libc6.chroot
+++ b/hooks/012-add-foreign-libc6.chroot
@@ -9,7 +9,7 @@ if [ "$(dpkg --print-architecture)" = "amd64" ]; then
     apt-get -y update
 
     echo "I: Installing libc6:i386 in amd64 image"
-    apt-get -y install libc6:i386
+    apt-get --no-install-recommends -y install libc6:i386
 fi
 
 echo "I: Checking if we are arm64 and libc6:armhf should be installed"
@@ -21,6 +21,6 @@ if [ "$(dpkg --print-architecture)" = "arm64" ]; then
     apt-get -y update
 
     echo "I: Installing libc6:armhf in arm64 image"
-    apt-get -y install libc6:armhf
+    apt-get --no-install-recommends -y install libc6:armhf
 fi
 


### PR DESCRIPTION
Do not install recommendations when installing libc6 for foreign
architectures and for installing the locally built console-conf and
friends, as this was installing a significant amount of packages that
we do not want in the base.

The now removed packages are:

gir1.2-glib-2.0:amd64
krb5-locales
libcom-err2:i386
libgirepository-1.0-1:amd64
libgssapi-krb5-2:i386
libidn2-0:i386
libk5crypto3:i386
libkeyutils1:i386
libkrb5-3:i386
libkrb5support0:i386
libnsl2:i386
libnss-nis:i386
libnss-nisplus:i386
libssl3:i386
libtirpc3:i386
libunistring2:i386
python3-gi