### PR TITLE
hooks: Add symlinks for bash completions of snap and snaps

### DIFF
--- a/hooks/050-snap-symlink.chroot
+++ b/hooks/050-snap-symlink.chroot
@@ -2,3 +2,12 @@
 
 echo "Creating the snap binary symlink"
 ln -s /snap/snapd/current/usr/bin/snap /usr/bin/snap
+
+echo "Creating the symlink to snap's bash completion"
+ln -s /snap/snapd/current/usr/share/bash-completion/completions/snap /usr/share/bash-completion/completions/snap
+
+echo "Creating the symlink snap's shell environment configuration"
+ln -s /snap/snapd/current/etc/profile.d/apps-bin-path.sh /etc/profile.d/apps-bin-path.sh
+
+echo "Creating the symlink snap's user services' environment configuration"
+ln -s /snap/snapd/current/usr/lib/environment.d/990-snapd.conf /usr/lib/environment.d/990-snapd.conf


### PR DESCRIPTION
Completion for `snap` must be present in
`/usr/share/bash-completion/completions/` and it must point to the
file in the active Snapd.

Other completion will be added in
`/var/lib/snapd/desktop/bash-completion/completions/` by Snapd. To be
able to access those `XDG_DATA_DIRS` has to be set by Snapd's
`profile.d` file.

This commits also adds snap's `environment.d` file which is used
by user services rather than interactive users.

This depends on snapcore/snapd#11038