### PR TITLE
snapcraft: add `assumes: [snapd2.55.5]`

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -8,7 +8,7 @@ confinement: strict
 type: base
 build-base: core22
 grade: stable
-assumes: [snapd-2.55.5]
+assumes: [snapd2.55.5]
 
 parts:
   probert-deb:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -8,6 +8,7 @@ confinement: strict
 type: base
 build-base: core22
 grade: stable
+assumes: [snapd-2.55.5]
 
 parts:
   probert-deb:


### PR DESCRIPTION
The `ensures: [snapd-2.55.5]` ensures that we have a version of
snapd that will *not* migrate ~/snap -> to ~/Snap for core22
using snapd.

Snapd 2.55.x before 2.55.5 would automatically create a
~/Snap/<snapname> folder for all the snaps that use `base: core22`.
However this is not what we want so to ensure this will not
happen we ensure that all the snapd versions used with core22 are
at least 2.55.5.