### PR TITLE
static/usr/lib/core: mount ubuntu-save to /var/lib/snapd/save

### DIFF
--- a/static/usr/lib/core/handle-writable-paths
+++ b/static/usr/lib/core/handle-writable-paths
@@ -181,6 +181,7 @@ main()
 		echo "/dev/root / rootfs defaults,ro 0 0" >> "$fstab"
 		handle_writable_paths "$writable_paths" "$fstab"
 		echo "/run/mnt/ubuntu-seed /var/lib/snapd/seed none bind,ro 0 0" >> "$fstab"
+		echo "/run/mnt/ubuntu-save /var/lib/snapd/save none bind,rw 0 0" >> "$fstab"
 	fi
 
 	# IMPORTANT: ensure we synced everything back to disk

--- a/static/usr/lib/core/handle-writable-paths
+++ b/static/usr/lib/core/handle-writable-paths
@@ -181,7 +181,6 @@ main()
 		echo "/dev/root / rootfs defaults,ro 0 0" >> "$fstab"
 		handle_writable_paths "$writable_paths" "$fstab"
 		echo "/run/mnt/ubuntu-seed /var/lib/snapd/seed none bind,ro 0 0" >> "$fstab"
-		echo "/run/mnt/ubuntu-save /var/lib/snapd/save none bind,rw 0 0" >> "$fstab"
 	fi
 
 	# IMPORTANT: ensure we synced everything back to disk

--- a/static/usr/lib/systemd/system/local-fs.target.requires/var-lib-snapd-save.mount
+++ b/static/usr/lib/systemd/system/local-fs.target.requires/var-lib-snapd-save.mount
@@ -1,0 +1,1 @@
+../var-lib-snapd-save.mount

--- a/static/usr/lib/systemd/system/var-lib-snapd-save.mount
+++ b/static/usr/lib/systemd/system/var-lib-snapd-save.mount
@@ -1,0 +1,8 @@
+[Unit]
+ConditionPathIsMountPoint=/run/mnt/ubuntu-save
+
+[Mount]
+What=/run/mnt/ubuntu-save
+Where=/var/lib/snapd/save
+Options=bind
+Type=none

--- a/tests/spread/main/basic/task.yaml
+++ b/tests/spread/main/basic/task.yaml
@@ -43,5 +43,7 @@ execute: |
   execute_remote systemctl -q is-active systemd-timesyncd.service
 
   # Verify that ubuntu-seed and ubuntu-save has been mounted
-  execute_remote mount | awk '{if ($3 == "/var/lib/snapd/seed") { exit 0}} ENDFILE{exit -1}'
-  execute_remote mount | awk '{if ($3 == "/var/lib/snapd/save") { exit 0}} ENDFILE{exit -1}'
+  # ubuntu-seed should be mounted readonly
+  # ubuntu-save should be mounted readwrite
+  execute_remote mount | awk '{if ($3 == "/var/lib/snapd/seed" && index($6, "ro")) { exit 0}} ENDFILE{exit -1}'
+  execute_remote mount | awk '{if ($3 == "/var/lib/snapd/save" && index($6, "rw")) { exit 0}} ENDFILE{exit -1}'

--- a/tests/spread/main/basic/task.yaml
+++ b/tests/spread/main/basic/task.yaml
@@ -41,3 +41,7 @@ execute: |
   execute_remote systemctl -q is-active systemd-journald.service
   execute_remote systemctl -q is-active systemd-resolved.service
   execute_remote systemctl -q is-active systemd-timesyncd.service
+
+  # Verify that ubuntu-seed and ubuntu-save has been mounted
+  execute_remote mount | awk '{if ($3 == "/var/lib/snapd/seed") { exit 0}} ENDFILE{exit -1}'
+  execute_remote mount | awk '{if ($3 == "/var/lib/snapd/save") { exit 0}} ENDFILE{exit -1}'

--- a/tests/spread/main/basic/task.yaml
+++ b/tests/spread/main/basic/task.yaml
@@ -47,3 +47,12 @@ execute: |
   # ubuntu-save should be mounted readwrite
   execute_remote mount | awk '{if ($3 == "/var/lib/snapd/seed" && index($6, "ro")) { exit 0}} ENDFILE{exit -1}'
   execute_remote mount | awk '{if ($3 == "/var/lib/snapd/save" && index($6, "rw")) { exit 0}} ENDFILE{exit -1}'
+  
+  # Verify that ubuntu-save has been mounted earlier than local-fs.target and not by snapd
+  # at a later stage. This is related to PR https://github.com/snapcore/snapd/pull/11850
+  UCSAVE_MOUNT_TIME=$(execute_remote systemctl show -p ActiveEnterTimestampMonotonic --value var-lib-snapd-save.mount)
+  LOCALFS_MOUNT_TIME=$(execute_remote systemctl show -p ActiveEnterTimestampMonotonic --value local-fs.target)
+  if [ "$UCSAVE_MOUNT_TIME" -ge "$LOCALFS_MOUNT_TIME" ]; then
+    echo "ubuntu-save was not mounted before local-fs.target"
+    exit 1
+  fi


### PR DESCRIPTION
As a part of the customer request to have a per-snap folder on the ubuntu-save partition, and because we do not want to expose the /run/mnt path to apparmor, we instead mount ubuntu-save into /var/lib/snapd as 'save'. This is already done by snap, but this happens to late in the startup process, and would create a dependency between snaps and snapd.