### PR TITLE
subiquity: update to 22.05.1

### DIFF
--- a/hooks/101-do-not-print-issue.chroot
+++ b/hooks/101-do-not-print-issue.chroot
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# In core16 we did not actually print /etc/issue on the terminal as
-# console-conf does that for us.  Probably something changed in agetty?
-# We can hack around it by explicitly forwarding -i to the agetty command.
-
-sed -i 's/\/sbin\/agetty /\/sbin\/agetty -i /' /lib/systemd/system/console-conf@.service /lib/systemd/system/serial-console-conf\@.service

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -54,7 +54,7 @@ parts:
     source: https://github.com/canonical/subiquity.git
     source-type: git
     # following branch server/jammy
-    source-commit: 8f9f97c69bb36048ea4c9e16be34bca3ac141771
+    source-commit: eb99b18d7aed92754053806cb5a812557637955d
     override-pull: |
       craftctl default
       # install build dependencies


### PR DESCRIPTION
Also remove hook script that was working around an old version of subiquity. 