### PR TITLE
hooks: Improve robustness of fix-ld-so-symlink hook

### DIFF
--- a/hook-tests/029-fix-ld-so-symlink.test
+++ b/hook-tests/029-fix-ld-so-symlink.test
@@ -1,31 +1,39 @@
-#!/bin/sh
+#!/bin/bash
 
-set -e
+set -eu
 
 # amd64
-abis="/lib64/ld-linux-x86-64.so.2"
+abis=("/lib64/ld-linux-x86-64.so.2")
 # i386
-abis="$abis /lib/ld-linux.so.2"
+abis+=("/lib/ld-linux.so.2")
 # ppc64el
-abis="$abis /lib64/ld64.so.2"
+abis+=("/lib64/ld64.so.2")
 # s390x
-abis="$abis /lib/ld64.so.1"
+abis+=("/lib/ld64.so.1")
 # armhf
-abis="$abis /lib/ld-linux-armhf.so.3"
+abis+=("/lib/ld-linux-armhf.so.3")
 # arm64
-abis="$abis /lib/ld-linux-aarch64.so.1"
+abis+=("/lib/ld-linux-aarch64.so.1")
 # riscv64
-abis="$abis /lib/ld-linux-riscv64-ld64d.so.1"
+abis+=("/lib/ld-linux-riscv64-ld64d.so.1")
+
+absolute_paths=()
 
 for abi in $abis; do
 	if [ -e ".$abi" ]; then
-		target=$(readlink ".$abi")
-		case $target in
+		target="$(readlink ".$abi")"
+		case "${target}" in
 			/*)
-				echo "ld linker .$abi is absolute"
-				echo "$target"
-				exit 1
+				absolute_paths+=("${abi} => ${target}")
 				;;
 		esac
 	fi
 done
+
+if [ ${#absolute_paths[@]} -gt 0 ]; then
+	echo "Found some absolute paths to dynamic linkers:" 1>&2
+	for p in "${absolute_paths[@]}"; do
+		echo "  ${p}" 1>&2
+	done
+	exit 1
+fi

--- a/hooks/029-fix-ld-so-symlink.chroot
+++ b/hooks/029-fix-ld-so-symlink.chroot
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-set -e
+set -eu
 
 echo "Making the abosolute /lib64/ld-linux-x86-64.so.2 symlinks relative"
 
@@ -10,28 +10,27 @@ echo "Making the abosolute /lib64/ld-linux-x86-64.so.2 symlinks relative"
 # Most architectures have their abi links relative, expect for some (amd64 & ppc64el)
 
 # amd64
-abis="/lib64/ld-linux-x86-64.so.2"
+abis=("/lib64/ld-linux-x86-64.so.2")
 # i386
-abis="$abis /lib/ld-linux.so.2"
+abis+=("/lib/ld-linux.so.2")
 # ppc64el
-abis="$abis /lib64/ld64.so.2"
+abis+=("/lib64/ld64.so.2")
 # s390x
-abis="$abis /lib/ld64.so.1"
+abis+=("/lib/ld64.so.1")
 # armhf
-abis="$abis /lib/ld-linux-armhf.so.3"
+abis+=("/lib/ld-linux-armhf.so.3")
 # arm64
-abis="$abis /lib/ld-linux-aarch64.so.1"
+abis+=("/lib/ld-linux-aarch64.so.1")
 # riscv64
-abis="$abis /lib/ld-linux-riscv64-ld64d.so.1"
+abis+=("/lib/ld-linux-riscv64-ld64d.so.1")
 
-for abi in $abis; do
-	if [ -e "$abi" ]; then
-		target=$(readlink "$abi")
-		case $target in
+for abi in "${abis[@]}"; do
+	if [ -L "${abi}" ]; then
+		target="$(readlink "$abi")"
+		case "${target}" in
 			/*)
-				ln -f -s .."$(readlink "$abi")" "$abi"
+				ln -srf "${target}" "${abi}"
 				;;
 		esac
 	fi
 done
-


### PR DESCRIPTION
Just some pedantic changes
 - Use bash syntax
 - Disallow undefined variables
 - Do not assume there is no space in paths (though unlikely)
 - Do not assume that the symlinks have a specific path depth
 - Ignore non symlinks (still fail in test)
 - Show all errors in the test instead of exiting on first error