### PR TITLE
Refactor extra-packages hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,16 +31,16 @@ install:
 		mknod -m 666 $(DESTDIR)/dev/urandom c 1 9
 	# copy static files verbatim
 	/bin/cp -a static/* $(DESTDIR)
-	/bin/cp $(CRAFT_PART_INSTALL)/../../probert-deb/install/*.deb $(DESTDIR)/tmp
-	/bin/cp $(CRAFT_PART_INSTALL)/../../consoleconf-deb/install/*.deb $(DESTDIR)/tmp
+	mkdir -p $(DESTDIR)/install-data
+	/bin/cp -r $(CRAFT_STAGE)/local-debs $(DESTDIR)/install-data/local-debs
 	# customize
-	set -ex; for f in ./hooks/[0-9]*.chroot; do \
-		/bin/cp -a $$f $(DESTDIR)/tmp && \
-		if ! chroot $(DESTDIR) /tmp/$$(basename $$f); then \
-                    exit 1; \
-                fi && \
-		rm -f $(DESTDIR)/tmp/$$(basename $$f); \
-	done;
+	set -eux; for f in ./hooks/[0-9]*.chroot; do		\
+		base="$$(basename "$${f}")";			\
+		cp -a "$${f}" $(DESTDIR)/install-data/;		\
+		chroot $(DESTDIR) "/install-data/$${base}";	\
+		rm "$(DESTDIR)/install-data/$${base}";		\
+	done
+	rm -rf $(DESTDIR)/install-data
 
 	# only generate manifest and dpkg.yaml files for lp build
 	if [ -e /build/core22 ]; then \

--- a/build-package.sh
+++ b/build-package.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -eu
+
+case "$1" in
+    pull)
+        craftctl default
+        export DEBIAN_FRONTEND=noninteractive
+        export DEBCONF_NONINTERACTIVE_SEEN=true
+        apt-get build-dep -y ./
+        ;;
+    build)
+        # unset the LD_FLAGS and LD_LIBRARY_PATH vars that snapcraft sets for us
+        # as those will point to the $CRAFT_STAGE which on re-builds will
+        # contain things like libc and friends that confuse the debian package
+        # build system
+        # TODO: should we unset $PATH to not include $CRAFT_STAGE too?
+        unset LD_FLAGS
+        unset LD_LIBRARY_PATH
+        # run the real build (but just build the binary package, and don't
+        # bother compressing it too much)
+        dpkg-buildpackage -b -uc -us -Zgzip -zfast
+        mkdir -p "${CRAFT_PART_INSTALL}/local-debs"
+        source="$(dpkg-parsechangelog -SSource)"
+        version="$(dpkg-parsechangelog -SVersion)"
+        arch="$(dpkg --print-architecture)"
+        dcmd mv "../${source}_${version}_${arch}.changes" "${CRAFT_PART_INSTALL}/local-debs"
+        ;;
+    stage)
+        craftctl default
+        cd "${CRAFT_STAGE}/local-debs"
+        dpkg-scanpackages . >Packages
+        apt-ftparchive release . >Release
+        ;;
+esac

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eux
 
@@ -40,60 +40,79 @@ Ht/skh2wZSHtJgejt9kqIKMho1wtYz7ZTqMtN9GJK0VONbHP0Xu6
 
 EOF
 
+cat <<EOF >/etc/apt/sources.list.d/local-packages.list
+deb [trusted=yes] file:/install-data/local-debs ./
+EOF
+
+# This gives higher priority to local-debs repository
+cat <<EOF >/etc/apt/preferences
+Package: *
+Pin: origin ""
+Pin-Priority: 1001
+EOF
+
 # install some packages we need
 apt update
 apt dist-upgrade -y
-apt install --no-install-recommends -y \
-    systemd \
-    systemd-sysv \
-    systemd-timesyncd \
-    finalrd \
-    libnss-extrausers \
-    libpam-systemd \
-    libpam-modules \
-    distro-info-data \
-    tzdata \
-    openssh-server \
-    iproute2 \
-    iptables \
-    kmod \
-    udev \
-    sudo \
-    less \
-    dbus \
-    dbus-user-session \
-    vim-tiny \
-    bash-completion \
-    netcat-openbsd \
-    iputils-ping \
-    apparmor \
-    netplan.io \
-    ca-certificates \
-    dosfstools \
-    squashfs-tools \
-    rfkill \
-    wpasupplicant \
-    cloud-init \
-    dmsetup \
-    cryptsetup \
+
+PACKAGES=(
+    apparmor
+    bash-completion
     bzip2
+    ca-certificates
+    cloud-init
+    cryptsetup
+    dbus
+    dbus-user-session
+    distro-info-data
+    dmsetup
+    dosfstools
+    finalrd
+    iproute2
+    iptables
+    iputils-ping
+    kmod
+    less
+    libnss-extrausers
+    libpam-modules
+    libpam-systemd
+    netcat-openbsd
+    netplan.io
+    openssh-server
+    rfkill
+    squashfs-tools
+    sudo
+    systemd
+    systemd-sysv
+    systemd-timesyncd
+    tzdata
+    udev
+    vim-tiny
+    wpasupplicant
+)
+
+# Locally built packages
+PACKAGES+=(
+    console-conf
+    probert-common
+    probert-network
+    subiquitycore
+)
 
 case "$(dpkg --print-architecture)" in
     riscv64)
         ;;
     *)
-        apt install --no-install-recommends -y gdbserver systemd-bootchart
+        PACKAGES+=(gdbserver systemd-bootchart)
         ;;
 esac
-
-# Install self-built console-conf
-find /tmp -name '*.deb' -print0 | xargs -0 apt install --no-install-recommends -y
-rm /tmp/*.deb
-
-apt autoremove -y
 
 case "$(dpkg --print-architecture)" in
     amd64|i386)
-        apt install --no-install-recommends -y secureboot-db
+        PACKAGES+=(secureboot-db)
         ;;
 esac
+
+apt install --no-install-recommends -y "${PACKAGES[@]}"
+
+apt autoremove -y

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,57 +13,37 @@ assumes: [snapd2.55.5]
 parts:
   probert-deb:
     plugin: nil
+    build-packages:
+      - devscripts
     source: https://github.com/canonical/probert.git
     source-type: git
     # following branch server/jammy
     source-commit: 253acbe1480fba69d12d6e72f53412da79e27410
     override-pull: |
-      craftctl default
-      # install build dependencies
-      export DEBIAN_FRONTEND=noninteractive
-      export DEBCONF_NONINTERACTIVE_SEEN=true
-      apt-get build-dep -y ./
+      "${CRAFT_PROJECT_DIR}/build-package.sh" pull
     override-build: |
-      # unset the LD_FLAGS and LD_LIBRARY_PATH vars that snapcraft sets for us
-      # as those will point to the $CRAFT_STAGE which on re-builds will
-      # contain things like libc and friends that confuse the debian package
-      # build system
-      # TODO: should we unset $PATH to not include $CRAFT_STAGE too?
-      unset LD_FLAGS
-      unset LD_LIBRARY_PATH
-      # run the real build (but just build the binary package, and don't
-      # bother compressing it too much)
-      dpkg-buildpackage -b -uc -us -Zgzip -zfast
-      cp ../probert-{network,common}*.deb $CRAFT_PART_INSTALL
-    stage:
-      - -probert*.deb
+      "${CRAFT_PROJECT_DIR}/build-package.sh" build
+    override-stage: |
+      "${CRAFT_PROJECT_DIR}/build-package.sh" stage
+    prime:
+      - -local-debs
+
   consoleconf-deb:
+    build-packages:
+      - devscripts
     plugin: nil
     source: https://github.com/canonical/subiquity.git
     source-type: git
     # following branch server/jammy
     source-commit: abc053508fa27656f1016e32585077ef567ad591
     override-pull: |
-      craftctl default
-      # install build dependencies
-      export DEBIAN_FRONTEND=noninteractive
-      export DEBCONF_NONINTERACTIVE_SEEN=true
-      apt-get build-dep -y ./
+      "${CRAFT_PROJECT_DIR}/build-package.sh" pull
     override-build: |
-      # unset the LD_FLAGS and LD_LIBRARY_PATH vars that snapcraft sets for us
-      # as those will point to the $CRAFT_STAGE which on re-builds will
-      # contain things like libc and friends that confuse the debian package
-      # build system
-      # TODO: should we unset $PATH to not include $CRAFT_STAGE too?
-      unset LD_FLAGS
-      unset LD_LIBRARY_PATH
-      # run the real build (but just build the binary package, and don't
-      # bother compressing it too much)
-      dpkg-buildpackage -b -uc -us -Zgzip -zfast
-      cp ../console-conf_*.deb ../subiquitycore_*.deb $CRAFT_PART_INSTALL
-    stage:
-      - -console-conf_*.deb
-      - -subiquitycore_*.deb
+      "${CRAFT_PROJECT_DIR}/build-package.sh" build
+    override-stage: |
+      "${CRAFT_PROJECT_DIR}/build-package.sh" stage
+    prime:
+      - -local-debs
 
   base:
     plugin: nil


### PR DESCRIPTION
* Use stage area to provide packages across snapcraft parts instead of
  using `$(CRAFT_PART_INSTALL)/../..`
* Make a local debian package repository
* Send all built binary packages to `extra-packages` hook. This is to
  avoid version mismatch in case some dependency start requiring other
  built packages
* Install all extra packages at once