### PR TITLE
Fix rebuild of bootstrap part

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ install:
 		echo "no DESTDIR set"; \
 		exit 1; \
 	fi
+	rm -rf $(DESTDIR)
 	cp -aT $(CRAFT_STAGE)/base $(DESTDIR)
 	# ensure resolving works inside the chroot
 	cat /etc/resolv.conf > $(DESTDIR)/etc/resolv.conf


### PR DESCRIPTION
If bootstrap has to rebuild and the install directory is partly
populated, then build will fail. We need to make sure the installation
directory is always cleaned up before building.