### PR TITLE
Makefile: create /usr/lib/clock-epoch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ install:
 	done
 	rm -rf $(DESTDIR)/install-data
 
+	# see https://github.com/systemd/systemd/blob/v247/src/shared/clock-util.c#L145
+	touch $(DESTDIR)/usr/lib/clock-epoch
+
 	# only generate manifest and dpkg.yaml files for lp build
 	if [ -e /build/core22 ]; then \
 		/bin/cp $(DESTDIR)/usr/share/snappy/dpkg.list /build/core22/core22-$$(date +%Y%m%d%H%M)_$(DPKG_ARCH).manifest; \


### PR DESCRIPTION
When there is no RTC systemd will use either it's own build date
or `/usr/lib/clock-epoch` to "seed" the initial time. So far we
did not create /usr/lib/clock-epoch but this commit adds it.

Forward-ported from
https://github.com/snapcore/core20/commit/ba61659045c4458175ef828f20f3a80fc62ee6db