### PR TITLE
doc: remove reference to using the impish rootfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This is a base snap for snapd & Ubuntu Core that is based on Ubuntu 22.04
 
-TODO: Not 22.04 actually yet, it will first build with impish rootfs and then we will switch to JJ when rootfs released.
-
 # Building locally
 
 To build this snap locally you need snapcraft. The project must be built as real root.


### PR DESCRIPTION
As the core22 is now based on the 22.04 rootfs, this TODO can be removed.

Signed-off-by: Isaac True <isaac.true@canonical.com>