### PR TITLE
pam: add optional faillock

### DIFF
--- a/hook-tests/031-faillock.test
+++ b/hook-tests/031-faillock.test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -eu
+
+grep pam_faillock.so etc/pam.d/common-auth

--- a/hooks/031-faillock.chroot
+++ b/hooks/031-faillock.chroot
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -eu
+
+pam-auth-update --enable optional-faillock optional-faillock-preauth optional-faillock-authsucc

--- a/static/usr/lib/core/lockout-not-enabled.sh
+++ b/static/usr/lib/core/lockout-not-enabled.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eu
+
+# This marker file is created by:
+# snap set system users.lockout=true
+! [ -f /etc/writable/account-locked.enable ]

--- a/static/usr/share/pam-configs/optional-lockout
+++ b/static/usr/share/pam-configs/optional-lockout
@@ -1,0 +1,7 @@
+Name: Optional lockout
+Default: yes
+Priority: 0
+Auth-Type: Primary
+Auth:
+    [success=1 default=ignore] pam_exec.so quiet /usr/lib/core/lockout-not-enabled.sh
+    [default=ignore] pam_faillock.so authfail

--- a/static/usr/share/pam-configs/optional-lockout-authsucc
+++ b/static/usr/share/pam-configs/optional-lockout-authsucc
@@ -1,0 +1,7 @@
+Name: Optional lockout (authsucc)
+Default: yes
+Priority: 0
+Auth-Type: Additional
+Auth:
+    [success=1 default=ignore] pam_exec.so quiet /usr/lib/core/lockout-not-enabled.sh
+    sufficient pam_faillock.so authsucc

--- a/static/usr/share/pam-configs/optional-lockout-preauth
+++ b/static/usr/share/pam-configs/optional-lockout-preauth
@@ -1,0 +1,7 @@
+Name: Optional lockout (preauth)
+Default: yes
+Priority: 2048
+Auth-Type: Primary
+Auth:
+    [success=1 default=ignore] pam_exec.so quiet /usr/lib/core/lockout-not-enabled.sh
+    requisite pam_faillock.so preauth

--- a/static/usr/share/pam-configs/snappy-extrausers
+++ b/static/usr/share/pam-configs/snappy-extrausers
@@ -3,9 +3,9 @@ Default: yes
 Priority: 257
 Auth-Type: Primary
 Auth:
-    [success=end authinfo_unavail=ignore default=die] pam_extrausers.so nodelay nullok try_first_pass
+    [success=end authinfo_unavail=ignore default=bad] pam_extrausers.so nodelay nullok try_first_pass
 Auth-Initial:
-    [success=end authinfo_unavail=ignore default=die] pam_extrausers.so nodelay nullok
+    [success=end authinfo_unavail=ignore default=bad] pam_extrausers.so nodelay nullok
 Password-Type: Primary
 Password:
 	[success=end default=ignore]      pam_extrausers.so minlen=4 sha512 use_authtok try_first_pass


### PR DESCRIPTION
When `/etc/writable/faillock.enabled` is present, then we use `pam_faillock` which can lock accounts for 900 seconds after 3 wrong password.

Can be tested with `faillock --user username`. Also use `faillock --user username --reset` instead of waiting 900 seconds.

Requires https://github.com/snapcore/snapd/pull/12278