### PR TITLE
Remove some unmounting errors on shutdown

### DIFF
--- a/static/usr/lib/systemd/system/keep-entangled-mounts.target
+++ b/static/usr/lib/systemd/system/keep-entangled-mounts.target
@@ -1,0 +1,7 @@
+[Unit]
+Description=Keep entangled mounts
+DefaultDependencies=no
+Wants=run-mnt-data.mount
+Wants=run-mnt-ubuntu\x2dseed.mount
+Wants=usr-lib-modules.mount
+Wants=run-mnt-kernel.mount

--- a/static/usr/lib/systemd/system/remount-data.service
+++ b/static/usr/lib/systemd/system/remount-data.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Remounting /run/mnt/data read-only
+DefaultDependencies=no
+ConditionPathIsMountPoint=/run/mnt/data
+After=umount.target
+Before=shutdown.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/mount -o remount,ro /run/mnt/data

--- a/static/usr/lib/systemd/system/remount-seed.service
+++ b/static/usr/lib/systemd/system/remount-seed.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Remounting /run/mnt/ubuntu-seed read-only
+DefaultDependencies=no
+ConditionPathIsMountPoint=/run/mnt/ubuntu-seed
+After=umount.target
+Before=shutdown.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/mount -o remount,ro /run/mnt/ubuntu-seed

--- a/static/usr/lib/systemd/system/run-mnt-data.mount.d/late-umount.conf
+++ b/static/usr/lib/systemd/system/run-mnt-data.mount.d/late-umount.conf
@@ -1,0 +1,3 @@
+[Unit]
+# This will remove implicit "Conflicts=umount.target"
+DefaultDependencies=no

--- a/static/usr/lib/systemd/system/run-mnt-kernel.mount.d/late-umount.conf
+++ b/static/usr/lib/systemd/system/run-mnt-kernel.mount.d/late-umount.conf
@@ -1,0 +1,3 @@
+[Unit]
+# This will remove implicit "Conflicts=umount.target"
+DefaultDependencies=no

--- a/static/usr/lib/systemd/system/run-mnt-ubuntu\x2dseed.mount.d/late-umount.conf
+++ b/static/usr/lib/systemd/system/run-mnt-ubuntu\x2dseed.mount.d/late-umount.conf
@@ -1,0 +1,3 @@
+[Unit]
+# This will remove implicit "Conflicts=umount.target"
+DefaultDependencies=no

--- a/static/usr/lib/systemd/system/shutdown.target.wants/keep-entangled-mounts.target
+++ b/static/usr/lib/systemd/system/shutdown.target.wants/keep-entangled-mounts.target
@@ -1,0 +1,1 @@
+../keep-entangled-mounts.target

--- a/static/usr/lib/systemd/system/shutdown.target.wants/remount-data.service
+++ b/static/usr/lib/systemd/system/shutdown.target.wants/remount-data.service
@@ -1,0 +1,1 @@
+../remount-data.service

--- a/static/usr/lib/systemd/system/shutdown.target.wants/remount-seed.service
+++ b/static/usr/lib/systemd/system/shutdown.target.wants/remount-seed.service
@@ -1,0 +1,1 @@
+../remount-seed.service

--- a/static/usr/lib/systemd/system/usr-lib-modules.mount.d/late-umount.conf
+++ b/static/usr/lib/systemd/system/usr-lib-modules.mount.d/late-umount.conf
@@ -1,0 +1,3 @@
+[Unit]
+# This will remove implicit "Conflicts=umount.target"
+DefaultDependencies=no


### PR DESCRIPTION
Because `/` is a squashfs from `/run/mnt/data`, we cannot unmount `/run/mnt/data`. (Or `/run/mnt/ubuntu-seed` during install/recovery).

So we need to disable `/run/mnt/data` by adding it to `shutdown.target`. However we need also to remount read-only. To avoid with writable bind mounts, we need to do it after `umount.target`.

This does not remove errors from finalrd which will be fixed in a different PR.

Note for testing: this happens after journald has stopped writing to logs. So you need to use serial port to properly log the errors.