### PR TITLE
Simplify systemd configuration for console-conf

### DIFF
--- a/hooks/009-fix-console-conf.chroot
+++ b/hooks/009-fix-console-conf.chroot
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -eu
+
+rm /usr/lib/systemd/system/getty@.service.d/console-conf.conf
+
+cat <<EOF >/usr/lib/systemd/system/getty@.service.d/console-conf.conf
+[Unit]
+ConditionPathExists=/var/lib/console-conf/complete
+ConditionPathExists=!/run/snapd-recovery-chooser-triggered
+EOF
+
+rm /usr/lib/systemd/system/serial-getty@.service.d/console-conf-serial.conf
+
+cat <<EOF >/usr/lib/systemd/system/serial-getty@.service.d/console-conf-serial.conf
+[Unit]
+ConditionPathExists=/var/lib/console-conf/complete
+EOF
+
+for unit in console-conf@.service serial-console-conf@.service; do
+    mkdir -p "/usr/lib/systemd/system/${unit}.d"
+    cat <<EOF >"/usr/lib/systemd/system/${unit}.d/core.conf"
+[Unit]
+# console-conf will try to stop itself. It should not.
+RefuseManualStop=true
+[Service]
+# console-conf should try to start or stop getty@%i
+ExecStartPre=
+ExecStopPost=
+EOF
+done
+
+ln -s /usr/lib/systemd/system/console-conf@.service /etc/systemd/system/getty.target.wants/console-conf@tty1.service

--- a/static/usr/lib/systemd/system-generators/serial-console-conf
+++ b/static/usr/lib/systemd/system-generators/serial-console-conf
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -eux
+
+NORMAL_DIR="${1}"
+EARLY_DIR="${2}"
+LATE_DIR="${3}"
+
+for tty in $(cat /sys/class/tty/console/active); do
+    case "${tty}" in
+      tty[0-9]*)
+      ;;
+      *)
+        mkdir -p "${NORMAL_DIR}/getty.target.wants"
+        ln -sf /usr/lib/systemd/system/serial-console-conf@.service "${NORMAL_DIR}/getty.target.wants/serial-console-conf@${tty}.service"
+      ;;
+    esac
+done


### PR DESCRIPTION
Having `getty@.service` and `console-conf@.service` starting each others seem to generate errors on shut down.

```
[  115.522870] systemctl[1011]: Got message type=error sender=org.freedesktop.systemd1 destination=n/a path=n/a interface=n/a member=n/a cookie=1 reply_cookie=1 signature=s error-name=org.freedesktop.systemd1.TransactionIsDestructive error-message=Transaction for getty@tty1.service/star
[  115.524325] systemctl[1011]: t is destructive (systemd-poweroff.service has 'start' job queued, but 'stop' is included in transaction).
[  115.525067] systemctl[1011]: Failed to start getty@tty1.service: Transaction for getty@tty1.service/start is destructive (systemd-poweroff.service has 'start' job queued, but 'stop' is included in transaction).
```

Instead we should just have both `console-conf@` and `getty@` enabled and select with conditions.

Serial port services are enabled by a generator, in a similar way as `systemd-getty-generator` for `serial-getty@`.

Automatic service for virtual terminals will not for console-conf however.  This is because logind starts `autovt@.service` which is a symlink to `getty@`. To have console-conf on autovt, we would need to have `autovt@.service` start both `getty@` and `console-conf@`. However the feature of having console-conf on all VTs is pretty useless and does not justify a hack.