### PR TITLE
Fix mount propagation

### DIFF
--- a/static/usr/lib/core/remount-core-fs
+++ b/static/usr/lib/core/remount-core-fs
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+FILESYSTEMS=(
+    /run/mnt/base
+    /run/mnt/data
+    /run/mnt/gadget
+    /run/mnt/kernel
+    /run/mnt/snapd
+    /run/mnt/ubuntu-boot
+    /run/mnt/ubuntu-save
+    /run/mnt/ubuntu-seed
+    /writable
+)
+
+for fs in "${FILESYSTEMS[@]}"; do
+    if mountpoint -q "${fs}"; then
+        mount --make-private "${fs}"
+    fi
+done

--- a/static/usr/lib/systemd/system/local-fs.target.wants/remount-core-fs.service
+++ b/static/usr/lib/systemd/system/local-fs.target.wants/remount-core-fs.service
@@ -1,0 +1,1 @@
+../remount-core-fs.service

--- a/static/usr/lib/systemd/system/remount-core-fs.service
+++ b/static/usr/lib/systemd/system/remount-core-fs.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Reset propagation of initial mount points
+DefaultDependencies=no
+Before=local-fs-pre.target
+Before=local-fs.target
+Before=shutdown.target
+Wants=local-fs-pre.target
+Conflicts=shutdown.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/lib/core/remount-core-fs
+
+[Install]
+WantedBy=local-fs.target


### PR DESCRIPTION
To switch root, systemd has to recursively make all mounts private, then after it recursively make all mounts shared.

However `/run/mnt/*` and `/writable` are used to be bind mounted in the rest of the file system. For example, there is no reason for mount `/snap/hello/42` to also show up as
`/writable/system-data/snap/hello/42` and
`/run/mnt/data/system-data/snap/hello/42`.