### PR TITLE
os-release: add "ubuntu" in ID_LIKE

### DIFF
--- a/hooks/018-set-os-release.chroot
+++ b/hooks/018-set-os-release.chroot
@@ -8,4 +8,5 @@ PRETTY_NAME="Ubuntu Core 22"
 VERSION_ID="22"
 HOME_URL="https://snapcraft.io/"
 BUG_REPORT_URL="https://bugs.launchpad.net/snappy/"
+ID_LIKE="ubuntu"
 EOF


### PR DESCRIPTION
fwupd finds the distro boot directory in EFI partition based on os-release. Because we use `ubuntu` as directory name, we need to have it in the ID_LIKE so that fwupd finds it.