### PR TITLE
snapd.sshd-keygen.service: fix unit dependency to sshd

### DIFF
--- a/static/usr/lib/systemd/system/snapd.sshd-keygen.service
+++ b/static/usr/lib/systemd/system/snapd.sshd-keygen.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Generate sshd host keys
-Before=sshd.service
+Before=ssh.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The correct name is `ssh.service`