### PR TITLE
Rework disabling of unmounts

### DIFF
--- a/hooks/101-systemd-fsck.chroot
+++ b/hooks/101-systemd-fsck.chroot
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eux
+
+echo "Remove conflict from systemd-fsck to shutdown"
+sed -i "/^Conflicts=shutdown.target$/d" lib/systemd/system/systemd-fsck@.service
+

--- a/static/usr/lib/systemd/system/keep-entangled-mounts.target
+++ b/static/usr/lib/systemd/system/keep-entangled-mounts.target
@@ -1,7 +1,0 @@
-[Unit]
-Description=Keep entangled mounts
-DefaultDependencies=no
-Wants=run-mnt-data.mount
-Wants=run-mnt-ubuntu\x2dseed.mount
-Wants=usr-lib-modules.mount
-Wants=run-mnt-kernel.mount

--- a/static/usr/lib/systemd/system/shutdown.target.wants/keep-entangled-mounts.target
+++ b/static/usr/lib/systemd/system/shutdown.target.wants/keep-entangled-mounts.target
@@ -1,1 +1,0 @@
-../keep-entangled-mounts.target

--- a/static/usr/lib/systemd/system/system-systemd\x2dfsck.slice
+++ b/static/usr/lib/systemd/system/system-systemd\x2dfsck.slice
@@ -1,0 +1,6 @@
+# We need to mark this slice as not conflicting with shutdown.target.
+# Otherwise it would drag mounts to be unmounted.
+[Unit]
+Description=Fsck Units Slice
+DefaultDependencies=no
+


### PR DESCRIPTION
Some mounts cannot be unmounted during `shutdown.target`.  We have tried make them part of `shutdown.target` so they are kept alive. But because they depend on `system-systemd\\x2dfsck.slice` and `systemd-fsck@.service` which both conflict with `shutdown.target`, it confuses systemd, and the result of what gets scheduled is not deterministic.

Instead we remove conflicts of `system-systemd\\x2dfsck.slice` and `systemd-fsck@.service`. Then `DefaultDependencies=no` on mounts is enough to disable unmounts.