### PR TITLE
Make all supported locale aliases to C

### DIFF
--- a/hook-tests/009-locale-archive.test
+++ b/hook-tests/009-locale-archive.test
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -eux
+
+[ -L usr/lib/locale/en_US.UTF-8 ]
+[ -d usr/lib/locale/C.utf8 ]

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -117,6 +117,7 @@ PACKAGES=(
     udev
     vim-tiny
     wpasupplicant
+    locales
 )
 
 # Locally built packages

--- a/hooks/009-locale-archive.chroot
+++ b/hooks/009-locale-archive.chroot
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eu
+
+mkdir -p "/usr/lib/locale"
+
+declare -A found_encodings
+
+while read -r locale encoding; do
+    encoding_canonical="$(echo "${encoding}" | sed 's/[A-Z]/\l&/g;s/[^a-z0-9]//g')"
+    case "${locale}" in
+        C|C.*)
+        ;;
+        *)
+            ln -s "C.${encoding_canonical}" "/usr/lib/locale/${locale}"
+        ;;
+    esac
+    found_encodings["${encoding}"]="${encoding_canonical}"
+done </usr/share/i18n/SUPPORTED
+
+for encoding in "${!found_encodings[@]}"; do
+    encoding_canonical="${found_encodings[${encoding}]}"
+    localedef --no-archive -f "${encoding}" -i C "C.${encoding_canonical}"
+done
+
+apt purge -y locales


### PR DESCRIPTION
This is needed for `ln_langinfo(CODESET)` to return the right encoding.

This adds around 750K in size.

It fixes https://github.com/fwupd/fwupd/issues/5484