### PR TITLE
[Core22] hooks: include ppa:ubuntu-security/fde-ice as part of the builds

### DIFF
--- a/hook-tests/001-extra-packages.test
+++ b/hook-tests/001-extra-packages.test
@@ -131,3 +131,7 @@ if [ -n "$DIFF" ]; then
     echo "test_pkg_removal.sh test."
     exit 1
 fi
+
+# TODO: test is not ideal but at this point we have no apt/dpkg db anymore
+echo "Ensure that the cryptsetup version is pulled from the fde-ice ppa"
+grep -E 'cryptsetup.*+ice' usr/share/snappy/dpkg.list 

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -71,6 +71,26 @@ Pin: origin ""
 Pin-Priority: 1001
 EOF
 
+# enable security ICE ppa
+echo "deb http://ppa.launchpadcontent.net/ubuntu-security/fde-ice/ubuntu $CODENAME main" > /etc/apt/sources.list.d/fde-ice.list
+
+cat >/etc/apt/trusted.gpg.d/canonical-security-fde-ice.asc <<'EOF'
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+xo0ESXbhhAEEAMgPw5cjuQparAFSRh4v/yrXGefOE4KzlV+OudbHPn/nxfhgXn1d
+RaF47lO+HLeBGd6X5UJzai//WoJcOPUBqLoiHIHgNr2pIi5iN29uZYnpEaN+LZyx
+pgM0db/jRzLFtBHM61ocKHflk/F9WeWMkSModxivBFK4NDpucEQzMzR1ABEBAAHN
+LkxhdW5jaHBhZCBQcml2YXRlIFBQQSBmb3IgVWJ1bnR1IFNlY3VyaXR5IFRlYW3C
+tgQTAQIAIAUCSXbhhAIbAwYLCQgHAwIEFQIIAwQWAgMBAh4BAheAAAoJEGjrQbzZ
+Mk9xo2kEAJCFZlNeFPiWUXpaOOVLsi5ZWST5RLIHiXJQgNHd+pqcxy9MpSUYZC/+
+J4rBYeOdB1v4qgJqVrks8b0Nixcvu0p7+ieZYP10fNt2uuNlj56eSV2v3z64VmZz
+ebrtrD1Hrw3BetRY4aQ0ysRSugvbTwqS0d17zepomYJS49Jy2w2D
+=ALlI
+-----END PGP PUBLIC KEY BLOCK-----
+
+EOF
+
+
 # install some packages we need
 apt update
 apt dist-upgrade -y


### PR DESCRIPTION
The security team maintains a PPA with the user-space parts of cryptsetup support for the Inline Crypto Engine (ICE) code.

This needs to be included in the core build so that FDE on ICE is supported.

The full ICE implementation uses:
https://github.com/chrisccoulson/linux/tree/dm-blk-crypto https://github.com/chrisccoulson/cryptsetup/tree/ice-wip

and is getting upstreamed by the kernel and security teams.