### PR TITLE
Don't include secureboot-db

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -155,12 +155,6 @@ case "$(dpkg --print-architecture)" in
         ;;
 esac
 
-case "$(dpkg --print-architecture)" in
-    amd64|i386)
-        PACKAGES+=(secureboot-db)
-        ;;
-esac
-
 apt install --no-install-recommends -y "${PACKAGES[@]}"
 
 apt autoremove -y

--- a/static/usr/lib/systemd/system/core.start-snapd.service
+++ b/static/usr/lib/systemd/system/core.start-snapd.service
@@ -1,8 +1,6 @@
 [Unit]
 Description=Start the snapd services from the snapd snap
 RequiresMountsFor=/run
-Wants=secureboot-db.service
-After=secureboot-db.service
 
 [Service]
 ExecStart=/usr/lib/core/run-snapd-from-snap start


### PR DESCRIPTION
The secureboot-db package exists to update dbx at boot to revoke insecure certificates/binaries.  However, changing dbx changes the measurements in the TPM, and we seal against these measurements when doing full-disk encryption.  So we need to NOT update dbx as a result of updating the core snap, but instead need dbx updates to be managed more directly by snapd.