### PR TITLE
static: correct the service name used in hctosys rtc fix rule

### DIFF
--- a/static/usr/lib/udev/rules.d/90-fix-hctosys.rules
+++ b/static/usr/lib/udev/rules.d/90-fix-hctosys.rules
@@ -1,3 +1,3 @@
 # when rtc* is added run a workaround script, see
 # https://github.com/snapcore/core20/pull/136
-ACTION=="add", SUBSYSTEM=="rtc", KERNEL=="rtc*", TAG+="systemd", ENV{SYSTEMD_WANTS}="fix-htctosys.service"
+ACTION=="add", SUBSYSTEM=="rtc", KERNEL=="rtc*", TAG+="systemd", ENV{SYSTEMD_WANTS}="fix-hctosys.service"


### PR DESCRIPTION
https://github.com/snapcore/core-base/pull/77 was created to address problem reported in https://bugs.launchpad.net/baoshan/+bug/1987724

The added udev rule refer to service file that does not exist (fix-h**t**ctosys.service)

This was discovered in core22.