### PR TITLE
static: correct service name used in hctosys rtc fix rule

### DIFF
--- a/static/usr/lib/udev/rules.d/90-fix-hctosys.rules
+++ b/static/usr/lib/udev/rules.d/90-fix-hctosys.rules
@@ -1,3 +1,3 @@
 # when rtc* is added run a workaround script, see
 # https://github.com/snapcore/core20/pull/136
-ACTION=="add", SUBSYSTEM=="rtc", KERNEL=="rtc*", TAG+="systemd", ENV{SYSTEMD_WANTS}="fix-htctosys.service"
+ACTION=="add", SUBSYSTEM=="rtc", KERNEL=="rtc*", TAG+="systemd", ENV{SYSTEMD_WANTS}="fix-hctosys.service"


### PR DESCRIPTION
Backport fix https://github.com/snapcore/core-base/pull/121 from branch main to core22.