### PR TITLE
static: correct clock epoch file in script fix-hctosys

### DIFF
--- a/static/usr/lib/core/fix-hctosys
+++ b/static/usr/lib/core/fix-hctosys
@@ -18,7 +18,7 @@
 #printf "%s\n" "Starting $(date)"
 
 TIMESYNC_CLOCK=/var/lib/systemd/timesync/clock
-CLOCK_EPOCH=/var/lib/clock-epoch
+CLOCK_EPOCH=/usr/lib/clock-epoch
 SELF=$(readlink -f "$0")
 
 NOW="$(date +'%s')"


### PR DESCRIPTION
Correct CLOCK_EPOCH.

This change is also proposed for backporting to core22 (branch) and core20 (repository):
 - https://github.com/snapcore/core-base/pull/126
 - https://github.com/snapcore/core20/pull/147