### PR TITLE
Remove pcrphase

### DIFF
--- a/hook-tests/027-remove-pcrphase.test
+++ b/hook-tests/027-remove-pcrphase.test
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -eu
+
+! [ -f lib/systemd/systemd-pcrphase ]
+for f in \
+  lib/systemd/systemd-pcrphase \
+  lib/systemd/system/*/systemd-pcrphase*.service \
+  lib/systemd/system/systemd-pcrphase*.service
+do
+  ! [ -f "${f}" ]
+  ! [ -L "${f}" ]
+done

--- a/hooks/027-remove-pcrphase.chroot
+++ b/hooks/027-remove-pcrphase.chroot
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -eux
+
+# systemd-pcrphase depends on tpm2-tss which we do not provide
+# systemd-pcrphase measures the phase of the boot in PCR 11.  PCR 11
+# is meant to measure signed kernel sections (see systemd-measure)
+# We are not yet using that PCR.
+
+rm /lib/systemd/systemd-pcrphase
+rm /lib/systemd/system/*/systemd-pcrphase*.service
+rm /lib/systemd/system/systemd-pcrphase*.service


### PR DESCRIPTION
pcrphase depends on a library that we do not provide. Since we do not use PCR 11, we can drop it for now.