### PR TITLE
Do not fail when pcrphase files do not exist

### DIFF
--- a/hooks/027-remove-pcrphase.chroot
+++ b/hooks/027-remove-pcrphase.chroot
@@ -7,6 +7,6 @@ set -eux
 # is meant to measure signed kernel sections (see systemd-measure)
 # We are not yet using that PCR.
 
-rm /lib/systemd/systemd-pcrphase
-rm /lib/systemd/system/*/systemd-pcrphase*.service
-rm /lib/systemd/system/systemd-pcrphase*.service
+rm -f /lib/systemd/systemd-pcrphase
+rm -f /lib/systemd/system/*/systemd-pcrphase*.service
+rm -f /lib/systemd/system/systemd-pcrphase*.service


### PR DESCRIPTION
On s390x, systemd-pcrphase is not installed.