### PR TITLE
Create again folders in /etc/NetworkManager

### DIFF
--- a/hooks/020-extra-files.chroot
+++ b/hooks/020-extra-files.chroot
@@ -42,6 +42,9 @@ ln -s ../lib/snapd/snapctl /usr/bin/snapctl
 echo "creating host mounts dir"
 mkdir -p /host
 
+echo "create mount points for network-manager snap layouts"
+mkdir -p /etc/NetworkManager/dispatcher.d
+
 echo "set static file and folder permissions"
 chmod 0755 /etc/systemd/system.conf.d
 chmod 0644 /etc/systemd/system.conf.d/11-snapd-ctrl-alt-del-burst.conf


### PR DESCRIPTION
A recent cloud-init update (23.2.1) removed the only file inside /etc/NetworkManager, so the folder disappeared from the snap. However, this folder is used by the network-manager snap layouts, so we need to keep it so bind mounts on it still work.