### PR TITLE
hooks: add hook to remove fixup-timesyncd.conf from base image

### DIFF
--- a/hooks/901-remove_timesyncd_cleanup.chroot
+++ b/hooks/901-remove_timesyncd_cleanup.chroot
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+
+# Remove fixup-timesyncd.conf from the base image to ensure systemd-timesyncd.service
+# functions correctly.
+# 
+# fixup-timesyncd.conf extended systemd-tmpfiles-setup.service to remove the directory
+# /var/lib/systemd/timesync to ensure systemd can create a dynamic user symlink to that
+# directory. However, this is not required anymore and interferes with
+# systemd-timesyncd.service because it removes /var/lib/systemd/timesync/clock on every
+# reboot and no symlink is created to provide and alternative source of the file.
+echo "Remove fixup-timesyncd.conf if it exists"
+
+fixup_path="/lib/systemd/system/systemd-tmpfiles-setup.service.d"
+fixup_file="$fixup_path/fixup-timesyncd.conf"
+if [ -f $fixup_file ]; then
+    rm $fixup_file
+    if [ -z "$(ls -A "$fixup_path")" ]; then
+        rm -rf $fixup_path
+    fi
+fi


### PR DESCRIPTION
Remove fixup-timesyncd.conf from the base image to ensure systemd-timesyncd.service functions correctly.

Review Notes: 
- Not yet sure on what basis the hook numbers are allocated?
- Assume such a simple hook does not require a test?
- This needs to be backported to core22 as well, not required for core20.

CONCLUSION:
This issue was caused by not snap laying around in the build directory. Abandon.