### PR TITLE
90-rtc-sys-time-init.rules: Optimize

### DIFF
--- a/static/usr/lib/core/rtc-sys-time-init
+++ b/static/usr/lib/core/rtc-sys-time-init
@@ -40,6 +40,11 @@ journal() {
 # Expects single argument RTC device node /dev/rtc* (instance name dev-rtc* with escaping undone)
 dev_node=$1
 
+# ... or a path in /sys
+if ! [ -c "${dev_node}" ]; then
+    dev_node="$(udevadm info --query=property --path "${dev_node}" | sed "/^DEVNAME=/{;s///;q};d")"
+fi
+
 # Get systemd timestamp file created during core build
 clock_epoch_stamp=0
 if [ -e "/usr/lib/clock-epoch" ]; then

--- a/static/usr/lib/udev/rules.d/90-rtc-sys-time-init.rules
+++ b/static/usr/lib/udev/rules.d/90-rtc-sys-time-init.rules
@@ -1,12 +1,18 @@
+ACTION!="add", GOTO="rtc-sys-end"
+SUBSYSTEM!="rtc", GOTO="rtc-sys-end"
+KERNEL!="rtc*", GOTO="rtc-sys-end"
+
 # When device rtc* is added
 #     1) and the RTC module have successfully set system time from RTC (indicated with hctosys attribute)
 #     2) and the kernel command line does not contain parameter ubuntu_core.rtc_sys_time_init that will cause
 #        systemd generator rtc-sys-time-init-generator to instantiate rtc-sys-time-init@.service
 # instantiate rtc-sys-time-init@.service for the device node
-IMPORT{cmdline}="ubuntu_core.rtc_sys_time_init"
-ACTION=="add", SUBSYSTEM=="rtc", KERNEL=="rtc*", ATTR{hctosys}=="1", ENV{ubuntu_core.rtc_sys_time_init}!="?*", TAG+="systemd", PROGRAM="/usr/bin/systemd-escape --path %N", ENV{SYSTEMD_WANTS}+="rtc-sys-time-init@%c.service"
+IMPORT{cmdline}=="ubuntu_core.rtc_sys_time_init"
+ATTR{hctosys}=="1", ENV{ubuntu_core.rtc_sys_time_init}!="?*", PROGRAM=="/usr/bin/systemd-escape --path %N", ENV{SYSTEMD_WANTS}+="rtc-sys-time-init@%c.service"
 
 # When device rtc* is added create device unit dev-rtc*.device which is used by rtc-sys-time-init@.service
 # enabled by generator rtc-sys-time-init-generator when kernel command line contains parameter
 # ubuntu_core.rtc_sys_time_init=/dev/rtc*
-ACTION=="add", SUBSYSTEM=="rtc", KERNEL=="rtc*", TAG+="systemd"
+TAG+="systemd"
+
+LABEL="rtc-sys-end"

--- a/static/usr/lib/udev/rules.d/90-rtc-sys-time-init.rules
+++ b/static/usr/lib/udev/rules.d/90-rtc-sys-time-init.rules
@@ -8,7 +8,7 @@ KERNEL!="rtc*", GOTO="rtc-sys-end"
 #        systemd generator rtc-sys-time-init-generator to instantiate rtc-sys-time-init@.service
 # instantiate rtc-sys-time-init@.service for the device node
 IMPORT{cmdline}=="ubuntu_core.rtc_sys_time_init"
-ATTR{hctosys}=="1", ENV{ubuntu_core.rtc_sys_time_init}!="?*", PROGRAM=="/usr/bin/systemd-escape --path %N", ENV{SYSTEMD_WANTS}+="rtc-sys-time-init@%c.service"
+ATTR{hctosys}=="1", ENV{ubuntu_core.rtc_sys_time_init}!="?*", ENV{SYSTEMD_WANTS}+="rtc-sys-time-init@.service"
 
 # When device rtc* is added create device unit dev-rtc*.device which is used by rtc-sys-time-init@.service
 # enabled by generator rtc-sys-time-init-generator when kernel command line contains parameter


### PR DESCRIPTION
This is cherry-pick of https://github.com/snapcore/core20/pull/156

Two optimization here:
 * We filter IMPORT{cmdline}. This causes some system calls. On core20, it also reads UEFI variables. This is very slow. We used to read the cmdline on all device. Now we do it only on rtc devices.
 * We stop calling /usr/bin/systemd-escape.

The first optimization is the most effective part. On google cloud, we reduce the time to cold boot devices from around 30s to 4s.