### PR TITLE
hooks: enable polkit for unconfined processes

### DIFF
--- a/hooks/000-provide-uids-gids.chroot
+++ b/hooks/000-provide-uids-gids.chroot
@@ -115,6 +115,7 @@ _apt:x:117:65534:Reserved:/nonexistent:/bin/false
 syslog:x:108:114:Reserved:/home/syslog:/bin/false
 dnsmasq:x:109:65534:Reserved:/var/lib/misc:/bin/false
 tss:x:110:116:Reserved:/var/lib/tpm:/bin/false
+polkitd:x:111:120:polkit:/nonexistent:/usr/sbin/nologin
 EOF
 cp /etc/passwd /etc/passwd.orig # We make a copy for a later sanity-compare
 
@@ -148,6 +149,7 @@ _apt:*:16780:0:99999:7:::
 syslog:*:16521:0:99999:7:::
 dnsmasq:*:16644:0:99999:7:::
 tss:*:16701:0:99999:7:::
+polkitd:!*:19690::::::
 EOF
 cp /etc/shadow /etc/shadow.orig # We make a copy for a later sanity-compare
 
@@ -209,6 +211,7 @@ input:x:107:
 render:x:117:
 sgx:x:119:
 _ssh:x:118:
+polkitd:x:120:
 EOF
 cp /etc/group /etc/group.orig # We make a copy for a later sanity-compare
 
@@ -270,5 +273,6 @@ input:!::
 render:!::
 sgx:!::
 _ssh:!::
+polkitd:!*::
 EOF
 cp /etc/gshadow /etc/gshadow.orig # We make a copy for a later sanity-compare

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -129,6 +129,7 @@ PACKAGES=(
     p11-kit
     p11-kit-modules
     plymouth-label-ft
+    polkitd
     rfkill
     squashfs-tools
     sudo

--- a/hooks/602-cleanup-xml-core.chroot
+++ b/hooks/602-cleanup-xml-core.chroot
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Remove parts of the xml-core package - runnable bits are used by polkit
+# package postinst/prerm scripts and it is not needed after that.
+
+set -ex
+
+echo "I: Removing xml-core runnable bits"
+
+rm -r \
+    usr/bin/dh_installxmlcatalogs \
+    usr/sbin/update-xmlcatalog \
+    usr/share/debhelper/autoscripts \
+    usr/share/perl5/Debian/Debhelper/Sequence/xml_core.pm

--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -67,3 +67,5 @@
 /etc/update-motd.d                      auto                    persistent  transition  none
 # allow to update password policy
 /etc/security/pwquality.conf            auto                    persistent  transition  none
+# polkit
+/etc/polkit-1/rules.d                   auto                    persistent  none        none


### PR DESCRIPTION
polkit is needed in some cases for communication between services shipped in the base, for instance when systemd-networkd talks to systemd-hostnamed to set the hostname. Enable to fix these use cases. Note that this does not help yet if we want to use it from a snap.