### PR TITLE
hooks: enable polkit for unconfined processes

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -127,6 +127,7 @@ PACKAGES=(
     p11-kit
     p11-kit-modules
     plymouth-label-ft
+    polkitd
     rfkill
     squashfs-tools
     sudo


### PR DESCRIPTION
polkit is needed in some cases for communication between services shipped in the base, for instance when systemd-networkd talks to systemd-hostnamed to set the hostname. Enable to fix these use cases. Note that this does not help yet if we want to use it from a snap.

Backported from https://github.com/snapcore/core-base/pull/161

This turned out to be a smaller change than for core24 as on Ubuntu 22.04
* polkit runs as root, not as polkitd user
* polkit does not have a dependency on xml-core
* polkit does not create the /etc/polkit-1/rules.d folder