### PR TITLE
66-snapd-autoimport.rules: filter out non filesystem blocks

### DIFF
--- a/static/usr/lib/udev/rules.d/66-snapd-autoimport.rules
+++ b/static/usr/lib/udev/rules.d/66-snapd-autoimport.rules
@@ -1,2 +1,2 @@
-ACTION=="add|change", SUBSYSTEM=="block", KERNEL!="loop*", KERNEL!="ram*" \
+ACTION=="add|change", SUBSYSTEM=="block", KERNEL!="loop*", KERNEL!="ram*", ENV{ID_FS_USAGE}=="filesystem" \
     ENV{SYSTEMD_WANTS}+="snapd.autoimport-device@%k.service"


### PR DESCRIPTION
Because we might run `snap auto-import --mount` on a partition table block and its partition blocks at the same time, it might cause a conflict.  We then get an error like `/dev/sda1 already mounted or mount point busy.`.

To go around this issue, we trigger the service only for devices that are identified as filesystems.