### PR TITLE
Remove systemd-pcrmachine.service

### DIFF
--- a/hook-tests/027-remove-pcrphase.test
+++ b/hook-tests/027-remove-pcrphase.test
@@ -6,7 +6,9 @@ set -eu
 for f in \
   usr/lib/systemd/systemd-pcrphase \
   usr/lib/systemd/system/*/systemd-pcrphase*.service \
-  usr/lib/systemd/system/systemd-pcrphase*.service
+  usr/lib/systemd/system/systemd-pcrphase*.service \
+  usr/lib/systemd/system/*/systemd-pcrmachine.service \
+  usr/lib/systemd/system/systemd-pcrmachine.service
 do
   ! [ -f "${f}" ]
   ! [ -L "${f}" ]

--- a/hooks/027-remove-pcrphase.chroot
+++ b/hooks/027-remove-pcrphase.chroot
@@ -10,3 +10,5 @@ set -eux
 rm -f /usr/lib/systemd/systemd-pcrphase
 rm -f /usr/lib/systemd/system/*/systemd-pcrphase*.service
 rm -f /usr/lib/systemd/system/systemd-pcrphase*.service
+rm -f /usr/lib/systemd/system/*/systemd-pcrmachine.service
+rm -f /usr/lib/systemd/system/systemd-pcrmachine.service


### PR DESCRIPTION
This runs `systemd-pcrphase` which we do not use and we have removed.