### PR TITLE
writable-paths: add /usr/share/polkit-1/actions

### DIFF
--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -69,4 +69,4 @@
 /etc/security/pwquality.conf            auto                    persistent  transition  none
 # polkit
 /etc/polkit-1/rules.d                   auto                    persistent  none        none
-/usr/share/polkit-1/actions             auto                    persistent  transition  none
+/usr/share/polkit-1/actions             auto                    synced      transition  none

--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -69,4 +69,4 @@
 /etc/security/pwquality.conf            auto                    persistent  transition  none
 # polkit
 /etc/polkit-1/rules.d                   auto                    persistent  none        none
-/usr/share/polkit-1/actions             auto                    persistent  none        none
+/usr/share/polkit-1/actions             auto                    persistent  transition  none

--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -69,3 +69,4 @@
 /etc/security/pwquality.conf            auto                    persistent  transition  none
 # polkit
 /etc/polkit-1/rules.d                   auto                    persistent  none        none
+/usr/share/polkit-1/actions             auto                    persistent  none        none


### PR DESCRIPTION
Snapd writes polkit policies into `/usr/share/polkit-1/actions` as currently this is the only place supported by polkitd to load polices. There is no /etc alternative for the above currently.

Unfortunately this path is read-only currently in core24, and core24 is the only version that is relevant as that is the only one that includes polkitd currently.