### PR TITLE
hooks: drop non-essential files

### DIFF
--- a/hooks/603-cleanup-docs.chroot
+++ b/hooks/603-cleanup-docs.chroot
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# Prune unnecessary documentation, leave the copyright bits
+
+set -ex
+
+echo "I: Removing docs"
+
+# docs, drop changelogs and examples, but leave the copyright
+find usr/share/doc/ -name 'changelog.Debian.gz' -print -delete
+find usr/share/doc/ -depth -type d -name 'examples' -print -exec rm -rv \{\} \;
+rm -r usr/share/doc-base
+
+# drop info files (there is no info in core anyway)
+rm -rv usr/share/info
+rm usr/share/info.dir

--- a/hooks/604-cleanup-hwdb.chroot
+++ b/hooks/604-cleanup-hwdb.chroot
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# Remove hwdb input files, we are not rebuilding the hwdb binary at runtime.
+
+set -ex
+
+echo "I: Removing hwdb input files"
+
+find usr/lib/udev/hwdb.d/ -name "*.hwdb" -print -delete
+rmdir usr/lib/udev/hwdb.d

--- a/hooks/605-cleanup-gdb.chroot
+++ b/hooks/605-cleanup-gdb.chroot
@@ -1,0 +1,9 @@
+#!/bin/sh
+#
+# Remove gdb related files, since the base does not ship gdb the files the
+# auto-load plugins are not useful
+
+set -ex
+
+rm -rv usr/share/gdb
+rm -rv usr/share/gcc/python

--- a/hooks/699-cleanup-misc.chroot
+++ b/hooks/699-cleanup-misc.chroot
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Prune unnecessay bits that aren't worthy of getting their own dedicated file
+
+set -ex
+
+echo "I: Removing misc files"
+
+# lintian
+rm -rv usr/share/lintian
+# python suppression profile, but we don't ship valgrind in the base
+rm -rv usr/lib/valgrind
+# zsh completion files, but we don't ship zsh
+rm -rv usr/share/zsh
+# cmake scripts for bash completion installation
+rm -rv usr/share/cmake
+# bug reporting helpers (depend on yesno, which isn't included)
+rm -rv usr/share/bug
+# apport isn't included, so hooks are not used
+rm -rv usr/share/apport


### PR DESCRIPTION
A bunch of cleanups of files that appear to be unnecessary and do not need to be shipped in core24.

AMD64 core24 size goes down by 1604kB.