### PR TITLE
hooks: remove xkb data

### DIFF
--- a/hooks/606-cleanup-xkb.chroot
+++ b/hooks/606-cleanup-xkb.chroot
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# Remove xkb data files which were pulled in as transitive dependency for
+# plymouth
+
+set -xe
+
+echo "I: Removing xkb data"
+
+rm -rv /usr/share/X11/xkb
+rmdir /usr/share/X11


### PR DESCRIPTION
Drop xkb data files.

Based on #176 

AMD64 core24 size is reduced by 1124kB wrt. the snap obtained from #176, 2728kB in total vs current upstream.

Fixes #178 
