### PR TITLE
hooks: remove perl-base and adduser

### DIFF
--- a/hooks/300-remove-pkgs-late.chroot
+++ b/hooks/300-remove-pkgs-late.chroot
@@ -18,6 +18,3 @@ echo "Remove packages we no longer need after postinst/hooks"
 # --- openssh-client depends on adduser.
 # --- dbus-system-bus-common depends on adduser.
 dpkg --purge --force-depends --force-remove-essential perl-base adduser
-
-# cleanup perl modules left behind by other packages
-find / -type f -name '*.pm' -delete

--- a/hooks/300-remove-pkgs-late.chroot
+++ b/hooks/300-remove-pkgs-late.chroot
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -ex
+set -e
 
 echo "Remove packages we no longer need after postinst/hooks"
 

--- a/hooks/300-remove-pkgs-late.chroot
+++ b/hooks/300-remove-pkgs-late.chroot
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -ex
+
+echo "Remove packages we no longer need after postinst/hooks"
+
+# Who also uses perl stuff?
+# pam-auth-update, which we invoke in 200-enable-pwquality
+
+# remove perl from the base
+# perl-base requires --force-remove-essential since its considered an essential package
+#
+# adduser requires --purge
+# following packages depend on adduser (but only during postinst/postrm scripts afaict) 
+# --- wpasupplicant depends on adduser.
+# --- udev depends on adduser.
+# --- openssh-server depends on adduser.
+# --- openssh-client depends on adduser.
+# --- dbus-system-bus-common depends on adduser.
+dpkg --purge --force-depends --force-remove-essential perl-base adduser
+
+# cleanup perl modules left behind by other packages
+find / -type f -name '*.pm' -delete

--- a/hooks/606-cleanup-perl.chroot
+++ b/hooks/606-cleanup-perl.chroot
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -ex
+
+# remove perl executables
+rm usr/bin/c_rehash
+rm usr/bin/dh_bash-completion
+rm usr/bin/helpztags
+rm usr/bin/ucfq
+rm usr/sbin/luksformat
+rm usr/sbin/pam-auth-update
+rm usr/sbin/pam_getenv
+rm usr/sbin/install-sgmlcatalog
+rm usr/sbin/update-catalog
+rm usr/sbin/update-rc.d
+
+# remove perl libraries
+rm usr/lib/ssl/misc/CA.pl
+rm usr/lib/ssl/misc/tsget.pl
+rm -rv usr/share/perl5


### PR DESCRIPTION
This PR drops perl-base and adduser from the base.

Size is reduced 2.2MB