### PR TITLE
hooks: remove file, libmagic and its data

### DIFF
--- a/hooks/040-remove-pkgs.chroot
+++ b/hooks/040-remove-pkgs.chroot
@@ -4,3 +4,8 @@ set -e
 
 echo "Remove uneeded packages"
 dpkg -r --force-depends dh-python
+
+
+# Remove file which got pulled in by cracklib-runtime. We are discarding
+# cracklib-runtime binary programs in later hooks (601-clean-cracklib.chroot).
+dpkg -r --force-depends file libmagic1 libmagic-mgc


### PR DESCRIPTION
file is added as a dependendency of cracklib-runtime. However we already drop all the binary programos of cracklib-runtime package and only leave the cache files, hence file becomes non-essential. The libmagic dependency of file pulls in libmagic-mgc carrying a 8MB+ binary file with file identification data.

Saves ~500kB on the snap size.