### PR TITLE
hooks: dont gzip cracklib pwd

### DIFF
--- a/hooks/601-clean-cracklib.chroot
+++ b/hooks/601-clean-cracklib.chroot
@@ -16,5 +16,3 @@ rm /usr/sbin/create-cracklib-dict
 rm /usr/sbin/update-cracklib
 rm /usr/share/dict/cracklib-small
 rm /var/cache/cracklib/src-dicts
-
-gzip /var/cache/cracklib/cracklib_dict.pwd


### PR DESCRIPTION
chpasswd fails when the cracklib_dict.pwd is gzipped

```
echo test:ubuntu123 | sudo chpasswd
/var/cache/cracklib/cracklib_dict.pwd: No such file or directory
BAD PASSWORD: The password fails the dictionary check - error loading dictionary
```

without gzipping:

```
ubuntu@localhost:~$ echo ubuntu:my-long-username-password | sudo chpasswd
ubuntu@localhost:~$ 
```

We used to gzip it because of passwd looking for it with a gz extension (https://github.com/snapcore/core20/issues/143). But not gzipping it works for passwd:
```
ubuntu@localhost:~$ passwd ubuntu
Changing password for ubuntu.
(current) UNIX password: 
New password: 
Retype new password: 
passwd: password updated successfully
```