### PR TITLE
static/usr/lib/tmpfiles.d: create journald config drop-in directory

### DIFF
--- a/static/usr/lib/tmpfiles.d/journald-conf-d.conf
+++ b/static/usr/lib/tmpfiles.d/journald-conf-d.conf
@@ -1,0 +1,5 @@
+# Used to create the journald config drop-in dir
+#
+# See tmpfiles.d(5) for details
+
+d /etc/systemd/journald.conf.d


### PR DESCRIPTION
@bboozzoo as per the suggestion in MM.

This would allow us to be able to grant access to the journald.conf.d directory, allowing customers to create drop-ins and customize the journald experience.

I'll open similar ones for core22/core20 if we agree.

Per @valentindavid suggestion, use tmpfiles.d to create the directory as it won't be created otherwise because of how /etc/systemd is mounted in writable paths.