### PR TITLE
Replace usage of 'apt' with 'apt-get'

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -20,8 +20,8 @@ trap 'umount /proc' EXIT
 mkdir -p /var/log/journal
 
 # We need to install first the certificates as apt will need them for https to lp
-apt update
-apt install --no-install-recommends -y ca-certificates
+apt-get update
+apt-get install --no-install-recommends -y ca-certificates
 
 # shellcheck disable=SC1091
 CODENAME=$(. /etc/os-release; echo "$UBUNTU_CODENAME")
@@ -120,8 +120,8 @@ EOF
 
 
 # install some packages we need
-apt update
-apt dist-upgrade -y
+apt-get update
+apt-get dist-upgrade -y
 
 PACKAGES=(
     apparmor
@@ -186,12 +186,12 @@ case "$(dpkg --print-architecture)" in
         ;;
 esac
 
-apt install --no-install-recommends -y "${PACKAGES[@]}"
+apt-get install --no-install-recommends -y "${PACKAGES[@]}"
 
-apt autoremove -y
+apt-get autoremove -y
 
 # Copy snapd-generator, which will handle mounts for /lib/{firmware,modules}
-apt download snapd
+apt-get download snapd
 dpkg --fsys-tarfile snapd_*.deb |
        tar xf - ./usr/lib/systemd/system-generators/snapd-generator
 rm snapd_*.deb

--- a/hooks/009-locale-archive.chroot
+++ b/hooks/009-locale-archive.chroot
@@ -23,7 +23,7 @@ for encoding in "${!found_encodings[@]}"; do
     localedef --no-archive -f "${encoding}" -i C "C.${encoding_canonical}"
 done
 
-apt purge -y locales
+apt-get purge -y locales
 
 # restore configuration so the default locale can be found
 printf 'LANG=C.UTF-8\n' > /etc/locale.conf

--- a/tests/lib/external/snapd-testing-tools/tests/repack-kernel/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/repack-kernel/task.yaml
@@ -5,8 +5,8 @@ systems: [ubuntu-20.04-64]
 
 execute: |
     # install dependencies
-    apt update -yqq
-    apt install snapd
+    apt-get update -yqq
+    apt-get install snapd
 
     # download the kernel snap
     snap download pc-kernel --channel=20/stable --basename=upstream-pc-kernel

--- a/tests/lib/external/snapd-testing-tools/tools/repack-kernel
+++ b/tests/lib/external/snapd-testing-tools/tools/repack-kernel
@@ -32,8 +32,8 @@ setup_deps() {
 
     # carries ubuntu-core-initframfs
     add-apt-repository ppa:snappy-dev/image -y
-    apt update -y
-    apt install ubuntu-core-initramfs -y
+    apt-get update -y
+    apt-get install ubuntu-core-initramfs -y
 }
 
 get_kver() {

--- a/tests/lib/prepare-utils.sh
+++ b/tests/lib/prepare-utils.sh
@@ -131,11 +131,11 @@ get_core_snap_name() {
 }
 
 install_base_deps() {
-    sudo apt update -qq
+    sudo apt-get update -qq
 
     # these should already be installed in GCE and LXD images with the google/lxd-nested 
     # backend, but in qemu local images from qemu-nested, we might not have them
-    sudo apt install psmisc fdisk snapd mtools ovmf qemu-system-x86 sshpass whois -yqq
+    sudo apt-get install psmisc fdisk snapd mtools ovmf qemu-system-x86 sshpass whois -yqq
 
     # TODO: https://bugs.launchpad.net/snapd/+bug/1712808
     # There is a bug in snapd that prevents udev rules from reloading in privileged containers

--- a/tests/spread/ci/build-image/task.yaml
+++ b/tests/spread/ci/build-image/task.yaml
@@ -25,8 +25,8 @@ execute: |
     retry -d 1 -t 20 lxc exec $INSTANCE_NAME -- bash -c 'systemctl is-system-running --wait' || true
 
     # we build libtpms and swptm from source and preinstall that in the image for TPM emulation support
-    lxc exec $INSTANCE_NAME -- bash -c "apt update -yqq"
-    lxc exec $INSTANCE_NAME -- bash -c "apt install initramfs-tools-core psmisc fdisk openssh-server whois git coreutils net-tools iproute2 automake software-properties-common autoconf libtool gcc build-essential libssl-dev dh-exec pkg-config dh-autoreconf libtasn1-6-dev libjson-glib-dev libgnutls28-dev expect gawk socat libseccomp-dev make -yqq"
+    lxc exec $INSTANCE_NAME -- bash -c "apt-get update -yqq"
+    lxc exec $INSTANCE_NAME -- bash -c "apt-get install initramfs-tools-core psmisc fdisk openssh-server whois git coreutils net-tools iproute2 automake software-properties-common autoconf libtool gcc build-essential libssl-dev dh-exec pkg-config dh-autoreconf libtasn1-6-dev libjson-glib-dev libgnutls28-dev expect gawk socat libseccomp-dev make -yqq"
     lxc exec $INSTANCE_NAME -- bash -c "git clone https://github.com/stefanberger/libtpms"
     lxc exec $INSTANCE_NAME -- bash -c "git clone https://github.com/stefanberger/swtpm"
     lxc exec $INSTANCE_NAME -- bash -c "cd libtpms && ./autogen.sh --with-openssl --prefix=/usr --with-tpm2 && make -j4 && make install"


### PR DESCRIPTION
Using apt gives the following warning:
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.