### PR TITLE
hooks: do not remove dhcpcd-base

### DIFF
--- a/hooks/000-provide-uids-gids.chroot
+++ b/hooks/000-provide-uids-gids.chroot
@@ -116,6 +116,7 @@ syslog:x:108:114:Reserved:/home/syslog:/bin/false
 dnsmasq:x:109:65534:Reserved:/var/lib/misc:/bin/false
 tss:x:110:116:Reserved:/var/lib/tpm:/bin/false
 polkitd:x:111:120:polkit:/nonexistent:/usr/sbin/nologin
+dhcpcd:x:107:65534:DHCP Client Daemon,,,:/usr/lib/dhcpcd:/bin/false
 EOF
 cp /etc/passwd /etc/passwd.orig # We make a copy for a later sanity-compare
 
@@ -150,6 +151,7 @@ syslog:*:16521:0:99999:7:::
 dnsmasq:*:16644:0:99999:7:::
 tss:*:16701:0:99999:7:::
 polkitd:!*:19690::::::
+dhcpcd:!:19835::::::
 EOF
 cp /etc/shadow /etc/shadow.orig # We make a copy for a later sanity-compare
 

--- a/hooks/040-remove-pkgs.chroot
+++ b/hooks/040-remove-pkgs.chroot
@@ -9,10 +9,3 @@ dpkg -r --force-depends dh-python
 # Remove file which got pulled in by cracklib-runtime. We are discarding
 # cracklib-runtime binary programs in later hooks (601-clean-cracklib.chroot).
 dpkg -r --force-depends file libmagic1 libmagic-mgc
-
-# cloud-init pulls in dhcpcd-base which we aren't (currently)
-# interested in. It's marked as required, but cloud-init works with
-# multiple dhcp clients. This change occurred recently (from time of commit)
-# since isc-dhcp-client will be deprecated and is currently in the process
-# of being demoted from packages in main universe.
-dpkg --purge --force-depends dhcpcd-base

--- a/hooks/990-ensure-uids-gids.chroot
+++ b/hooks/990-ensure-uids-gids.chroot
@@ -24,10 +24,6 @@ echo "Ensure no docker"
 ! grep -q docker /etc/passwd /etc/shadow /etc/group /etc/gshadow
 rc=$?; [ "$rc" != "0" ] && MISMATCH=1
 
-echo "Ensure no user 107 (ex-docker)"
-cut -d: -f3 /etc/passwd | grep -q 107
-rc=$?; [ "$rc" = "0" ] && MISMATCH=1
-
 echo "Ensure no group 113 (ex-docker)"
 cut -d: -f3 /etc/group | grep -q 113
 rc=$?; [ "$rc" = "0" ] && MISMATCH=1


### PR DESCRIPTION
It seems that not having a dhcpcd-base client causes issues with usages of cloud-init. We see this on GCE and in Certifications testing when using the images.

As long as cloud-init is a part of the base, it makes better sense to also contain its dependencies.

For more info see:
https://github.com/snapcore/core-base/pull/186#issuecomment-2018299100
https://github.com/canonical/cloud-init/issues/5088

This can be causing the issue we are seeing in UC related to failing to create users through adduser - as it may be falling back to creating through that if it cannot otherwise resolve other data-sources.