### PR TITLE
snapcraft: switch to release image

### DIFF
--- a/hooks/014-set-motd.chroot
+++ b/hooks/014-set-motd.chroot
@@ -12,7 +12,7 @@ To learn how to create your custom Ubuntu Core image, see our guide:
 
 * Getting Started: https://ubuntu.com/core/docs/get-started
 
-In this image, why not try creating an IoT web-kiosk. First, connect a 
+In this image, why not create an IoT web-kiosk. First, connect a 
 screen, then run: 
 
    snap install ubuntu-frame wpe-webkit-mir-kiosk

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -17,12 +17,9 @@ parts:
     build-packages:
       - wget
     build-environment:
-      # When 24.04 is finally released:
-      #- RELEASE: "24.04"
-      #- BASE: ubuntu-base-${RELEASE}-base-${CRAFT_ARCH_BUILD_FOR}.tar.gz
-      #- DIR_URL: https://cdimage.ubuntu.com/ubuntu-base/releases/${RELEASE}/release
-      - BASE: noble-base-${CRAFT_ARCH_BUILD_FOR}.tar.gz
-      - DIR_URL: https://cdimage.ubuntu.com/ubuntu-base/daily/current
+      - RELEASE: "24.04"
+      - BASE: ubuntu-base-${RELEASE}-base-${CRAFT_ARCH_BUILD_FOR}.tar.gz
+      - DIR_URL: https://cdimage.ubuntu.com/ubuntu-base/releases/${RELEASE}/release
       - URL: ${DIR_URL}/${BASE}
       - SHA256: ${DIR_URL}/SHA256SUMS
       - SIG: ${SHA256}.gpg


### PR DESCRIPTION
The LP build was broken since the daily images are now ocular. Switch to the correct release images