### PR TITLE
bump subiquity and probert

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -18,8 +18,8 @@ parts:
       - devscripts
     source: https://github.com/canonical/probert.git
     source-type: git
-    # following branch server/jammy
-    source-commit: 253acbe1480fba69d12d6e72f53412da79e27410
+    # following branch core/jammy
+    source-commit: 94be2fa3f45e766ecee526fdc0c15f65a78667e6
     override-pull: |
       "${CRAFT_PROJECT_DIR}/build-package.sh" pull
     override-build: |
@@ -36,8 +36,8 @@ parts:
     plugin: nil
     source: https://github.com/canonical/subiquity.git
     source-type: git
-    # following branch server/jammy
-    source-commit: d2fe66f1b624274f2b1ff53bcbbc093cc9ebfca2
+    # following branch core/jammy
+    source-commit: c6452b904798d94d8dea7d00bb84cefbb98e3238
     override-pull: |
       "${CRAFT_PROJECT_DIR}/build-package.sh" pull
     override-build: |


### PR DESCRIPTION
This bumps probert and subiquity/console-conf to commits that have been relicensed to GPL3-only.

I have built the core22 snap locally with and without this change and the differences are only what is expected.

As the comment change suggests, I have created branched in the subiquity and probert repos to track the commits that go into core22, we could change core22 to follow those branches if that would make things smoother (and you trust us not to mess with them, I guess).