### PR TITLE
hooks,static: add support for systemd-coredump

### DIFF
--- a/hooks/000-provide-uids-gids.chroot
+++ b/hooks/000-provide-uids-gids.chroot
@@ -117,6 +117,7 @@ dnsmasq:x:109:65534:Reserved:/var/lib/misc:/bin/false
 tss:x:110:116:Reserved:/var/lib/tpm:/bin/false
 polkitd:x:111:120:polkit:/nonexistent:/usr/sbin/nologin
 dhcpcd:x:107:65534:DHCP Client Daemon,,,:/usr/lib/dhcpcd:/bin/false
+systemd-coredump:x:999:999:systemd Core Dumper:/:/usr/sbin/nologin
 EOF
 cp /etc/passwd /etc/passwd.orig # We make a copy for a later sanity-compare
 
@@ -152,6 +153,7 @@ dnsmasq:*:16644:0:99999:7:::
 tss:*:16701:0:99999:7:::
 polkitd:!*:19690::::::
 dhcpcd:!:19835::::::
+systemd-coredump:!*:99999::::::
 EOF
 cp /etc/shadow /etc/shadow.orig # We make a copy for a later sanity-compare
 
@@ -214,6 +216,7 @@ render:x:117:
 sgx:x:119:
 _ssh:x:118:
 polkitd:x:120:
+systemd-coredump:x:999:
 EOF
 cp /etc/group /etc/group.orig # We make a copy for a later sanity-compare
 
@@ -276,5 +279,6 @@ render:!::
 sgx:!::
 _ssh:!::
 polkitd:!*::
+systemd-coredump:!*::
 EOF
 cp /etc/gshadow /etc/gshadow.orig # We make a copy for a later sanity-compare

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -161,6 +161,7 @@ PACKAGES=(
     squashfs-tools
     sudo
     systemd
+    systemd-coredump
     systemd-sysv
     systemd-timesyncd
     systemd-resolved

--- a/static/usr/lib/tmpfiles.d/coredump-comf-d.conf
+++ b/static/usr/lib/tmpfiles.d/coredump-comf-d.conf
@@ -1,0 +1,5 @@
+# Used to create the coredump config drop-in dir
+#
+# See tmpfiles.d(5) for details
+
+d /etc/systemd/coredump.conf.d


### PR DESCRIPTION
This is a backport of https://github.com/snapcore/core-base/pull/227